### PR TITLE
Improve Decypharr configuration and Docker setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ Decypharr is the critical bridge between your media managers and TorBox. **Nothi
    - **Debrid** tab: TorBox API key should be shown ✓, Rclone Folder set to `/mnt/remote/torbox/__all__` ✓, WebDAV enabled ✓
    - **Rclone** tab: Mount should be **enabled** ✓, mount path `/mnt/remote` ✓
    - All of the above are pre-configured by the setup script — just verify they look correct
-4. ⚠️ **Do not click Save** — Decypharr's config is mounted read-only (`:ro`) as a security measure. If you need to change settings, edit the config file on the host (`torbox-media-server/configs/decypharr/config.json`) and restart the container, or re-run `setup.sh`.
+4. You can click **Save** if you change Decypharr settings. Its config directory is mounted persistently so the app can update `config.json` without entering a restart loop.
 
 **✅ What success looks like:** The Debrid tab shows your API key, WebDAV is enabled, and the Rclone tab shows the mount as active.
 
@@ -523,7 +523,7 @@ For remote access outside your home network, use a reverse proxy like [Caddy](ht
 - **Authentication is set to `Forms` with `DisabledForLocalAddresses`** after setup — **you must create login credentials** in each service's Settings → General before exposing them to your LAN (see Steps 2–4 in the walkthrough above)
 - **The `.env` file** contains your TorBox API key and *arr API keys — it's `chmod 600` (owner-read only). Don't commit it to version control
 - **Only Decypharr** gets `SYS_ADMIN` capability and FUSE access — other containers only read files via symlinks
-- **Decypharr config is mounted read-only** — the config directory is bound as `:ro` to prevent containers from modifying their own configuration
+- **Decypharr config is mounted writable** — Decypharr needs to update its own `config.json` at runtime, so the config directory is persisted on the host instead of mounted read-only
 
 ## Troubleshooting
 
@@ -652,7 +652,7 @@ This usually means Radarr or Sonarr hasn't finished starting yet. Wait a minute 
 - **jq for JSON manipulation** — used to modify *arr config via API; auto-installed as a dependency
 - **Quality profile upgrades enabled** — without this, Radarr/Sonarr won't replace a 720p version with a 1080p one; most users want automatic upgrades
 - **Docker images pinned to specific versions** — avoids breakage from upstream changes; re-run `setup.sh` to pick up newer versions intentionally
-- **Decypharr config mounted read-only** — config.json is bind-mounted as `:ro` to prevent containers from accidentally modifying it
+- **Decypharr config mounted writable** — Decypharr rewrites its config at runtime, so the host config directory is mounted at `/app` and persisted across restarts
 - **Decypharr credentials pre-seeded** — generated during setup and injected into config.json, eliminating manual credential creation
 - **Plex and Jellyfin on all interfaces** — both media servers expose their ports on all interfaces for LAN streaming consistency; other services remain localhost-only for security
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
   # Mocks qBittorrent API for Radarr/Sonarr, connects to TorBox,
   # handles WebDAV mounting via built-in rclone, and creates symlinks.
   decypharr:
-    image: "${DECYPHARR_IMAGE:-ghcr.io/sirrobot01/decypharr:v2.2}"
+    image: "${DECYPHARR_IMAGE:-cy01/blackhole:latest}"
     container_name: decypharr
     restart: unless-stopped
     networks:
@@ -50,7 +50,7 @@ services:
   # ── Prowlarr ───────────────────────────────────────────────────
   # Indexer manager - feeds search results to Radarr & Sonarr.
   prowlarr:
-    image: lscr.io/linuxserver/prowlarr:2.1.3
+    image: "${PROWLARR_IMAGE:-lscr.io/linuxserver/prowlarr:latest}"
     container_name: prowlarr
     restart: unless-stopped
     networks:
@@ -81,7 +81,7 @@ services:
   # ── Byparr ────────────────────────────────────────────────────
   # Cloudflare bypass proxy (Byparr - drop-in FlareSolverr replacement).
   byparr:
-    image: ghcr.io/thephaseless/byparr:1.2.2
+    image: "${BYPARR_IMAGE:-ghcr.io/thephaseless/byparr:latest}"
     container_name: byparr
     restart: unless-stopped
     networks:
@@ -108,7 +108,7 @@ services:
   # Movie management - searches, grabs, and organizes movies.
   # Uses Decypharr as its download client (qBittorrent mock).
   radarr:
-    image: lscr.io/linuxserver/radarr:5.22.4
+    image: "${RADARR_IMAGE:-lscr.io/linuxserver/radarr:latest}"
     container_name: radarr
     restart: unless-stopped
     networks:
@@ -142,7 +142,7 @@ services:
   # TV show management - searches, grabs, and organizes series.
   # Uses Decypharr as its download client (qBittorrent mock).
   sonarr:
-    image: lscr.io/linuxserver/sonarr:4.0.14
+    image: "${SONARR_IMAGE:-lscr.io/linuxserver/sonarr:latest}"
     container_name: sonarr
     restart: unless-stopped
     networks:
@@ -175,7 +175,7 @@ services:
   # ── Seerr ───────────────────────────────────────────────────────
   # Media request & discovery frontend.
   seerr:
-    image: ghcr.io/seerr-team/seerr:2.4.1
+    image: "${SEERR_IMAGE:-ghcr.io/seerr-team/seerr:latest}"
     container_name: seerr
     user: "${PUID}:${PGID}"
     restart: unless-stopped
@@ -203,7 +203,7 @@ services:
   # Media server option 1 - streams your library to any device.
   # Activated via COMPOSE_PROFILES=plex in .env
   plex:
-    image: lscr.io/linuxserver/plex:1.41.5
+    image: "${PLEX_IMAGE:-lscr.io/linuxserver/plex:latest}"
     profiles: ["plex"]
     container_name: plex
     restart: unless-stopped
@@ -237,7 +237,7 @@ services:
   # Media server option 2 (open-source) - streams your library.
   # Activated via COMPOSE_PROFILES=jellyfin in .env
   jellyfin:
-    image: lscr.io/linuxserver/jellyfin:10.10.7
+    image: "${JELLYFIN_IMAGE:-lscr.io/linuxserver/jellyfin:latest}"
     profiles: ["jellyfin"]
     container_name: jellyfin
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       - PGID=${PGID}
       - UMASK=002
     volumes:
-      - "${CONFIG_DIR}/decypharr:/app"
+      - "${CONFIG_DIR}/decypharr/config.json:/app/config.json:ro"
       - "/mnt:/mnt:rshared"
       - "${DATA_DIR}:/data"
     devices:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,14 +19,14 @@ services:
     networks:
       - media-network
     ports:
-      - "127.0.0.1:8282:8282"
+      - "8282:8282"
     environment:
       - PUID=${PUID}
       - PGID=${PGID}
       - UMASK=002
     volumes:
-      - "${CONFIG_DIR}/decypharr/config.json:/app/config.json:ro"
-      - "${MOUNT_DIR}:/mnt/remote:rshared"
+      - "${CONFIG_DIR}/decypharr:/app"
+      - "/mnt:/mnt:rshared"
       - "${DATA_DIR}:/data"
     devices:
       - /dev/fuse:/dev/fuse:rwm

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       - PGID=${PGID}
       - UMASK=002
     volumes:
-      - "${CONFIG_DIR}/decypharr/config.json:/app/config.json:ro"
+      - "${CONFIG_DIR}/decypharr:/app"
       - "/mnt:/mnt:rshared"
       - "${DATA_DIR}:/data"
     devices:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,12 +32,6 @@ services:
       - /dev/fuse:/dev/fuse:rwm
     cap_add:
       - SYS_ADMIN
-    healthcheck:
-      test: ["CMD", "curl", "-sf", "http://localhost:8282"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 30s
     logging:
       driver: json-file
       options:
@@ -126,7 +120,7 @@ services:
         max-file: "3"
     depends_on:
       decypharr:
-        condition: service_healthy
+        condition: service_started
     healthcheck:
       test: ["CMD", "curl", "-sf", "http://localhost:7878/ping"]
       interval: 30s
@@ -160,7 +154,7 @@ services:
         max-file: "3"
     depends_on:
       decypharr:
-        condition: service_healthy
+        condition: service_started
     healthcheck:
       test: ["CMD", "curl", "-sf", "http://localhost:8989/ping"]
       interval: 30s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
   # Mocks qBittorrent API for Radarr/Sonarr, connects to TorBox,
   # handles WebDAV mounting via built-in rclone, and creates symlinks.
   decypharr:
-    image: ghcr.io/sirrobot01/decypharr:v2.0
+    image: "${DECYPHARR_IMAGE:-ghcr.io/sirrobot01/decypharr:v2.2}"
     container_name: decypharr
     restart: unless-stopped
     networks:

--- a/setup.sh
+++ b/setup.sh
@@ -327,12 +327,12 @@ install_dependencies() {
         for dep in "${deps[@]}"; do
             case "$dep" in
                 docker)
-                    sudo pacman -S --noconfirm docker docker-compose-plugin
+                    sudo pacman -S --noconfirm docker docker-compose
                     sudo systemctl enable --now docker
                     sudo usermod -aG docker "$USER"
                     ;;
                 docker-compose)
-                    sudo pacman -S --noconfirm docker-compose-plugin
+                    sudo pacman -S --noconfirm docker-compose
                     ;;
                 curl)
                     sudo pacman -S --noconfirm curl

--- a/setup.sh
+++ b/setup.sh
@@ -2103,8 +2103,7 @@ configure_arr_auth() {
                 rm -f "${env_tmp}"
             fi
             chmod 600 "${ENV_FILE}"
-        }
-    } || log_warn "  Failed to configure ${name} auth."
+        } || log_warn "  Failed to configure ${name} auth."
 }
 
 # ============================================================================

--- a/setup.sh
+++ b/setup.sh
@@ -101,14 +101,20 @@ mask_key()    { local k="$1"; if [[ ${#k} -gt 4 ]]; then echo "${k:0:4}...${k: -
 
 # Service port registry (single source of truth for all port/label references)
 SVC_ORDER=(decypharr prowlarr byparr radarr sonarr seerr)
-declare -A SVC_PORTS=(
-    [decypharr]=8282 [prowlarr]=9696 [byparr]=8191
-    [radarr]=7878 [sonarr]=8989 [seerr]=5055
-)
-declare -A SVC_LABELS=(
-    [decypharr]="Decypharr" [prowlarr]="Prowlarr" [byparr]="Byparr"
-    [radarr]="Radarr" [sonarr]="Sonarr" [seerr]="Seerr"
-)
+declare -A SVC_PORTS
+SVC_PORTS["decypharr"]=8282
+SVC_PORTS["prowlarr"]=9696
+SVC_PORTS["byparr"]=8191
+SVC_PORTS["radarr"]=7878
+SVC_PORTS["sonarr"]=8989
+SVC_PORTS["seerr"]=5055
+declare -A SVC_LABELS
+SVC_LABELS["decypharr"]="Decypharr"
+SVC_LABELS["prowlarr"]="Prowlarr"
+SVC_LABELS["byparr"]="Byparr"
+SVC_LABELS["radarr"]="Radarr"
+SVC_LABELS["sonarr"]="Sonarr"
+SVC_LABELS["seerr"]="Seerr"
 
 print_service_urls() {
     local svc
@@ -942,7 +948,7 @@ JELLYFIN_IMAGE="${jellyfin_image}"
 ENV_EOF
 
     # Preserve existing admin credentials if this is a re-run
-    if [[ -n "${EXISTING_RADARR_ADMIN_USER:-}" ]]; then
+    if [[ -n "${EXISTING_RADARR_ADMIN_USER:-}" || -n "${EXISTING_SONARR_ADMIN_USER:-}" || -n "${EXISTING_PROWLARR_ADMIN_USER:-}" ]]; then
         cat >> "${ENV_FILE}" << ADMIN_EOF
 
 # Admin Credentials (Preserved)
@@ -1057,14 +1063,20 @@ NC='\033[0m'
 
 # Service port registry
 SVC_ORDER=(decypharr prowlarr byparr radarr sonarr seerr)
-declare -A SVC_PORTS=(
-    [decypharr]=8282 [prowlarr]=9696 [byparr]=8191
-    [radarr]=7878 [sonarr]=8989 [seerr]=5055
-)
-declare -A SVC_LABELS=(
-    [decypharr]="Decypharr" [prowlarr]="Prowlarr" [byparr]="Byparr"
-    [radarr]="Radarr" [sonarr]="Sonarr" [seerr]="Seerr"
-)
+declare -A SVC_PORTS
+SVC_PORTS["decypharr"]=8282
+SVC_PORTS["prowlarr"]=9696
+SVC_PORTS["byparr"]=8191
+SVC_PORTS["radarr"]=7878
+SVC_PORTS["sonarr"]=8989
+SVC_PORTS["seerr"]=5055
+declare -A SVC_LABELS
+SVC_LABELS["decypharr"]="Decypharr"
+SVC_LABELS["prowlarr"]="Prowlarr"
+SVC_LABELS["byparr"]="Byparr"
+SVC_LABELS["radarr"]="Radarr"
+SVC_LABELS["sonarr"]="Sonarr"
+SVC_LABELS["seerr"]="Seerr"
 
 # Safely read a value from .env without executing shell code
 env_val() {
@@ -2052,12 +2064,14 @@ add_default_indexer() {
 
 configure_arr_auth() {
     local name="$1" url="$2" api_key="$3"
+    local api_ver="v3"
+    [[ "$name" == "Prowlarr" ]] && api_ver="v1"
 
     log_step "Configuring ${name} authentication..."
 
     # Check current auth config
     local auth_config
-    auth_config=$(curl -sf --connect-timeout 5 --max-time 15 -H "X-Api-Key: ${api_key}" "${url}/api/v3/config/host" 2>/dev/null) || true
+    auth_config=$(curl -sf --connect-timeout 5 --max-time 15 -H "X-Api-Key: ${api_key}" "${url}/api/${api_ver}/config/host" 2>/dev/null) || true
     [[ -z "$auth_config" ]] && { log_warn "  Could not retrieve ${name} auth config."; return 1; }
 
     # Check if auth is already set to Forms
@@ -2075,13 +2089,6 @@ configure_arr_auth() {
         admin_pass="$(head -c 12 /dev/urandom | base64 | tr -d '/+=' | head -c 12)"
     fi
 
-    # Store credentials globally for post-install display
-    case "$name" in
-        Radarr)   RADARR_ADMIN_USER="$admin_user"; RADARR_ADMIN_PASS="$admin_pass" ;;
-        Sonarr)   SONARR_ADMIN_USER="$admin_user"; SONARR_ADMIN_PASS="$admin_pass" ;;
-        Prowlarr) PROWLARR_ADMIN_USER="$admin_user"; PROWLARR_ADMIN_PASS="$admin_pass" ;;
-    esac
-
     # Set auth to Forms with Enabled (always require login)
     local auth_id
     auth_id=$(echo "$auth_config" | jq -r '.id' 2>/dev/null) || true
@@ -2097,23 +2104,23 @@ configure_arr_auth() {
     curl -sf --connect-timeout 5 --max-time 15 -X PUT \
         -H "Content-Type: application/json" \
         -H "X-Api-Key: ${api_key}" \
-        "${url}/api/v3/config/host/${auth_id}" \
+        "${url}/api/${api_ver}/config/host/${auth_id}" \
         -d "$updated_auth" -o /dev/null 2>/dev/null && {
             log_info "  ${name} auth set to Forms (Enabled) with auto-generated credentials."
-            local env_key
+            local env_prefix
             case "$name" in
-                Radarr)   env_key="RADARR_ADMIN_USER" ;;
-                Sonarr)   env_key="SONARR_ADMIN_USER" ;;
-                Prowlarr) env_key="PROWLARR_ADMIN_USER" ;;
+                Radarr)   env_prefix="RADARR_ADMIN"; RADARR_ADMIN_USER="$admin_user"; RADARR_ADMIN_PASS="$admin_pass" ;;
+                Sonarr)   env_prefix="SONARR_ADMIN"; SONARR_ADMIN_USER="$admin_user"; SONARR_ADMIN_PASS="$admin_pass" ;;
+                Prowlarr) env_prefix="PROWLARR_ADMIN"; PROWLARR_ADMIN_USER="$admin_user"; PROWLARR_ADMIN_PASS="$admin_pass" ;;
                 *)        { log_warn "  Unsupported service name: ${name}"; return 1; } ;;
             esac
 
             # Remove old entries and append new ones
             local env_tmp
             env_tmp="$(mktemp "${ENV_FILE}.tmp.XXXXXX")"
-            if grep -v "^${env_key}_USER=\\|^${env_key}_PASS=" "${ENV_FILE}" > "${env_tmp}" 2>/dev/null; then
-                echo "${env_key}_USER=\"${admin_user}\"" >> "${env_tmp}"
-                echo "${env_key}_PASS=\"${admin_pass}\"" >> "${env_tmp}"
+            if grep -v "^${env_prefix}_USER=\\|^${env_prefix}_PASS=" "${ENV_FILE}" > "${env_tmp}" 2>/dev/null; then
+                echo "${env_prefix}_USER=\"${admin_user}\"" >> "${env_tmp}"
+                echo "${env_prefix}_PASS=\"${admin_pass}\"" >> "${env_tmp}"
                 mv "${env_tmp}" "${ENV_FILE}"
             else
                 rm -f "${env_tmp}"
@@ -2217,8 +2224,8 @@ print_post_install() {
     echo "   • Open http://localhost:9696"
     if [[ "$SERVICES_STARTED" == "true" && -n "${PROWLARR_ADMIN_PASS:-}" ]]; then
         echo -e "   • ${GREEN}Credentials pre-seeded ✓${NC}"
-        echo -e "   •   Username: ${BOLD}${PROWLARR_ADMIN_USER}${NC}"
-        echo -e "   •   Password: ${BOLD}${PROWLARR_ADMIN_PASS}${NC}"
+        echo -e "   •   Username: ${BOLD}${PROWLARR_ADMIN_USER:-<not set>}${NC}"
+        echo -e "   •   Password: ${BOLD}${PROWLARR_ADMIN_PASS:-<not set>}${NC}"
     else
         echo -e "   • ${YELLOW}Create login credentials (Settings → General → Authentication)${NC}"
     fi
@@ -2234,8 +2241,8 @@ print_post_install() {
     echo "   • Open http://localhost:7878"
     if [[ "$SERVICES_STARTED" == "true" && -n "${RADARR_ADMIN_PASS:-}" ]]; then
         echo -e "   • ${GREEN}Credentials pre-seeded ✓${NC}"
-        echo -e "   •   Username: ${BOLD}${RADARR_ADMIN_USER}${NC}"
-        echo -e "   •   Password: ${BOLD}${RADARR_ADMIN_PASS}${NC}"
+        echo -e "   •   Username: ${BOLD}${RADARR_ADMIN_USER:-<not set>}${NC}"
+        echo -e "   •   Password: ${BOLD}${RADARR_ADMIN_PASS:-<not set>}${NC}"
     else
         echo -e "   • ${YELLOW}Set up authentication (Settings → General → Authentication)${NC}"
     fi
@@ -2259,8 +2266,8 @@ print_post_install() {
     echo "   • Open http://localhost:8989"
     if [[ "$SERVICES_STARTED" == "true" && -n "${SONARR_ADMIN_PASS:-}" ]]; then
         echo -e "   • ${GREEN}Credentials pre-seeded ✓${NC}"
-        echo -e "   •   Username: ${BOLD}${SONARR_ADMIN_USER}${NC}"
-        echo -e "   •   Password: ${BOLD}${SONARR_ADMIN_PASS}${NC}"
+        echo -e "   •   Username: ${BOLD}${SONARR_ADMIN_USER:-<not set>}${NC}"
+        echo -e "   •   Password: ${BOLD}${SONARR_ADMIN_PASS:-<not set>}${NC}"
     else
         echo -e "   • ${YELLOW}Set up authentication (Settings → General → Authentication)${NC}"
     fi
@@ -2389,6 +2396,12 @@ print_post_install() {
 # ============================================================================
 
 SERVICES_STARTED=false
+RADARR_ADMIN_USER=""
+RADARR_ADMIN_PASS=""
+SONARR_ADMIN_USER=""
+SONARR_ADMIN_PASS=""
+PROWLARR_ADMIN_USER=""
+PROWLARR_ADMIN_PASS=""
 
 # Globals for re-run detection (set by check_existing_installation)
 EXISTING_RADARR_API_KEY=""
@@ -2411,7 +2424,7 @@ EXISTING_PLEX_IMAGE=""
 EXISTING_JELLYFIN_IMAGE=""
 
 check_existing_installation() {
-    if [[ -f "${SETUP_COMPLETE_FILE}" ]]; then
+    if [[ -f "${SETUP_COMPLETE_FILE}" || -f "${ENV_FILE}" || -f "${COMPOSE_FILE}" ]]; then
         log_section "Existing Installation Detected"
         log_warn "A previous installation was found at: ${INSTALL_DIR}"
         echo ""
@@ -2484,6 +2497,12 @@ check_existing_installation() {
         EXISTING_SONARR_ADMIN_PASS=$(grep '^SONARR_ADMIN_PASS=' "${ENV_FILE}" 2>/dev/null | cut -d= -f2- | tr -d '"' | tr -d "'") || true
         EXISTING_PROWLARR_ADMIN_USER=$(grep '^PROWLARR_ADMIN_USER=' "${ENV_FILE}" 2>/dev/null | cut -d= -f2- | tr -d '"' | tr -d "'") || true
         EXISTING_PROWLARR_ADMIN_PASS=$(grep '^PROWLARR_ADMIN_PASS=' "${ENV_FILE}" 2>/dev/null | cut -d= -f2- | tr -d '"' | tr -d "'") || true
+        RADARR_ADMIN_USER="${EXISTING_RADARR_ADMIN_USER}"
+        RADARR_ADMIN_PASS="${EXISTING_RADARR_ADMIN_PASS}"
+        SONARR_ADMIN_USER="${EXISTING_SONARR_ADMIN_USER}"
+        SONARR_ADMIN_PASS="${EXISTING_SONARR_ADMIN_PASS}"
+        PROWLARR_ADMIN_USER="${EXISTING_PROWLARR_ADMIN_USER}"
+        PROWLARR_ADMIN_PASS="${EXISTING_PROWLARR_ADMIN_PASS}"
 
         # Validate extracted API keys are valid 32-char hex; regenerate if corrupted
         if [[ -n "$EXISTING_RADARR_API_KEY" && ! "$EXISTING_RADARR_API_KEY" =~ ^[0-9a-f]{32}$ ]]; then

--- a/setup.sh
+++ b/setup.sh
@@ -883,7 +883,14 @@ PROWLARR_XML_EOF
 generate_env_file() {
     log_step "Generating environment file..."
 
-    local decypharr_image="${EXISTING_DECYPHARR_IMAGE:-${DECYPHARR_IMAGE:-ghcr.io/sirrobot01/decypharr:v2.2}}"
+    local decypharr_image="${EXISTING_DECYPHARR_IMAGE:-${DECYPHARR_IMAGE:-cy01/blackhole:latest}}"
+    local prowlarr_image="${EXISTING_PROWLARR_IMAGE:-${PROWLARR_IMAGE:-lscr.io/linuxserver/prowlarr:latest}}"
+    local byparr_image="${EXISTING_BYPARR_IMAGE:-${BYPARR_IMAGE:-ghcr.io/thephaseless/byparr:latest}}"
+    local radarr_image="${EXISTING_RADARR_IMAGE:-${RADARR_IMAGE:-lscr.io/linuxserver/radarr:latest}}"
+    local sonarr_image="${EXISTING_SONARR_IMAGE:-${SONARR_IMAGE:-lscr.io/linuxserver/sonarr:latest}}"
+    local seerr_image="${EXISTING_SEERR_IMAGE:-${SEERR_IMAGE:-ghcr.io/seerr-team/seerr:latest}}"
+    local plex_image="${EXISTING_PLEX_IMAGE:-${PLEX_IMAGE:-lscr.io/linuxserver/plex:latest}}"
+    local jellyfin_image="${EXISTING_JELLYFIN_IMAGE:-${JELLYFIN_IMAGE:-lscr.io/linuxserver/jellyfin:latest}}"
 
     # Set the compose profile based on media server choice
     local compose_profile="plex"
@@ -925,6 +932,13 @@ PROWLARR_API_KEY="${PROWLARR_API_KEY}"
 DECYPHARR_USER="${DECYPHARR_USER:-torbox}"
 DECYPHARR_PASS="${DECYPHARR_PASS:-}"
 DECYPHARR_IMAGE="${decypharr_image}"
+PROWLARR_IMAGE="${prowlarr_image}"
+BYPARR_IMAGE="${byparr_image}"
+RADARR_IMAGE="${radarr_image}"
+SONARR_IMAGE="${sonarr_image}"
+SEERR_IMAGE="${seerr_image}"
+PLEX_IMAGE="${plex_image}"
+JELLYFIN_IMAGE="${jellyfin_image}"
 ENV_EOF
 
     # Preserve existing admin credentials if this is a re-run
@@ -2389,6 +2403,13 @@ EXISTING_SONARR_ADMIN_PASS=""
 EXISTING_PROWLARR_ADMIN_USER=""
 EXISTING_PROWLARR_ADMIN_PASS=""
 EXISTING_DECYPHARR_IMAGE=""
+EXISTING_PROWLARR_IMAGE=""
+EXISTING_BYPARR_IMAGE=""
+EXISTING_RADARR_IMAGE=""
+EXISTING_SONARR_IMAGE=""
+EXISTING_SEERR_IMAGE=""
+EXISTING_PLEX_IMAGE=""
+EXISTING_JELLYFIN_IMAGE=""
 
 check_existing_installation() {
     if [[ -f "${SETUP_COMPLETE_FILE}" ]]; then
@@ -2426,6 +2447,36 @@ check_existing_installation() {
         EXISTING_TORBOX_API_KEY=$(grep '^TORBOX_API_KEY=' "${ENV_FILE}" 2>/dev/null | cut -d= -f2- | tr -d '"' | tr -d "'") || true
         EXISTING_COMPOSE_PROFILES=$(grep '^COMPOSE_PROFILES=' "${ENV_FILE}" 2>/dev/null | cut -d= -f2- | tr -d '"' | tr -d "'") || true
         EXISTING_DECYPHARR_IMAGE=$(grep '^DECYPHARR_IMAGE=' "${ENV_FILE}" 2>/dev/null | cut -d= -f2- | tr -d '"' | tr -d "'") || true
+        EXISTING_PROWLARR_IMAGE=$(grep '^PROWLARR_IMAGE=' "${ENV_FILE}" 2>/dev/null | cut -d= -f2- | tr -d '"' | tr -d "'") || true
+        EXISTING_BYPARR_IMAGE=$(grep '^BYPARR_IMAGE=' "${ENV_FILE}" 2>/dev/null | cut -d= -f2- | tr -d '"' | tr -d "'") || true
+        EXISTING_RADARR_IMAGE=$(grep '^RADARR_IMAGE=' "${ENV_FILE}" 2>/dev/null | cut -d= -f2- | tr -d '"' | tr -d "'") || true
+        EXISTING_SONARR_IMAGE=$(grep '^SONARR_IMAGE=' "${ENV_FILE}" 2>/dev/null | cut -d= -f2- | tr -d '"' | tr -d "'") || true
+        EXISTING_SEERR_IMAGE=$(grep '^SEERR_IMAGE=' "${ENV_FILE}" 2>/dev/null | cut -d= -f2- | tr -d '"' | tr -d "'") || true
+        EXISTING_PLEX_IMAGE=$(grep '^PLEX_IMAGE=' "${ENV_FILE}" 2>/dev/null | cut -d= -f2- | tr -d '"' | tr -d "'") || true
+        EXISTING_JELLYFIN_IMAGE=$(grep '^JELLYFIN_IMAGE=' "${ENV_FILE}" 2>/dev/null | cut -d= -f2- | tr -d '"' | tr -d "'") || true
+
+        # Migrate old legacy image references to current defaults
+        case "${EXISTING_DECYPHARR_IMAGE}" in
+            ghcr.io/sirrobot01/decypharr:v2.2) EXISTING_DECYPHARR_IMAGE="" ;;
+        esac
+        case "${EXISTING_PROWLARR_IMAGE}" in
+            lscr.io/linuxserver/prowlarr:2.1.3) EXISTING_PROWLARR_IMAGE="" ;;
+        esac
+        case "${EXISTING_BYPARR_IMAGE}" in
+            ghcr.io/thephaseless/byparr:1.2.2) EXISTING_BYPARR_IMAGE="" ;;
+        esac
+        case "${EXISTING_RADARR_IMAGE}" in
+            lscr.io/linuxserver/radarr:5.22.4) EXISTING_RADARR_IMAGE="" ;;
+        esac
+        case "${EXISTING_SONARR_IMAGE}" in
+            lscr.io/linuxserver/sonarr:4.0.14) EXISTING_SONARR_IMAGE="" ;;
+        esac
+        case "${EXISTING_SEERR_IMAGE}" in
+            ghcr.io/seerr-team/seerr:2.4.1) EXISTING_SEERR_IMAGE="" ;;
+        esac
+        case "${EXISTING_JELLYFIN_IMAGE}" in
+            lscr.io/linuxserver/jellyfin:10.10.7) EXISTING_JELLYFIN_IMAGE="" ;;
+        esac
 
         # Extract existing admin credentials
         EXISTING_RADARR_ADMIN_USER=$(grep '^RADARR_ADMIN_USER=' "${ENV_FILE}" 2>/dev/null | cut -d= -f2- | tr -d '"' | tr -d "'") || true

--- a/setup.sh
+++ b/setup.sh
@@ -883,6 +883,8 @@ PROWLARR_XML_EOF
 generate_env_file() {
     log_step "Generating environment file..."
 
+    local decypharr_image="${EXISTING_DECYPHARR_IMAGE:-${DECYPHARR_IMAGE:-ghcr.io/sirrobot01/decypharr:v2.2}}"
+
     # Set the compose profile based on media server choice
     local compose_profile="plex"
     if [[ "${MEDIA_SERVER}" == "jellyfin" ]]; then
@@ -922,6 +924,7 @@ PROWLARR_API_KEY="${PROWLARR_API_KEY}"
 # Decypharr credentials (pre-seeded)
 DECYPHARR_USER="${DECYPHARR_USER:-torbox}"
 DECYPHARR_PASS="${DECYPHARR_PASS:-}"
+DECYPHARR_IMAGE="${decypharr_image}"
 ENV_EOF
 
     # Preserve existing admin credentials if this is a re-run
@@ -2385,6 +2388,7 @@ EXISTING_SONARR_ADMIN_USER=""
 EXISTING_SONARR_ADMIN_PASS=""
 EXISTING_PROWLARR_ADMIN_USER=""
 EXISTING_PROWLARR_ADMIN_PASS=""
+EXISTING_DECYPHARR_IMAGE=""
 
 check_existing_installation() {
     if [[ -f "${SETUP_COMPLETE_FILE}" ]]; then
@@ -2421,6 +2425,7 @@ check_existing_installation() {
         EXISTING_PROWLARR_API_KEY=$(grep '^PROWLARR_API_KEY=' "${ENV_FILE}" 2>/dev/null | cut -d= -f2- | tr -d '"' | tr -d "'") || true
         EXISTING_TORBOX_API_KEY=$(grep '^TORBOX_API_KEY=' "${ENV_FILE}" 2>/dev/null | cut -d= -f2- | tr -d '"' | tr -d "'") || true
         EXISTING_COMPOSE_PROFILES=$(grep '^COMPOSE_PROFILES=' "${ENV_FILE}" 2>/dev/null | cut -d= -f2- | tr -d '"' | tr -d "'") || true
+        EXISTING_DECYPHARR_IMAGE=$(grep '^DECYPHARR_IMAGE=' "${ENV_FILE}" 2>/dev/null | cut -d= -f2- | tr -d '"' | tr -d "'") || true
 
         # Extract existing admin credentials
         EXISTING_RADARR_ADMIN_USER=$(grep '^RADARR_ADMIN_USER=' "${ENV_FILE}" 2>/dev/null | cut -d= -f2- | tr -d '"' | tr -d "'") || true

--- a/setup.sh
+++ b/setup.sh
@@ -1210,7 +1210,6 @@ case "${1:-help}" in
         echo -e "  ${BOLD}Radarr${NC}    $(env_val RADARR_API_KEY)"
         echo -e "  ${BOLD}Sonarr${NC}    $(env_val SONARR_API_KEY)"
         echo -e "  ${BOLD}Prowlarr${NC}  $(env_val PROWLARR_API_KEY)"
-        local _radarr_pass _sonarr_pass _prowlarr_pass
         _radarr_pass="$(env_val RADARR_ADMIN_PASS)"
         _sonarr_pass="$(env_val SONARR_ADMIN_PASS)"
         _prowlarr_pass="$(env_val PROWLARR_ADMIN_PASS)"

--- a/setup.sh
+++ b/setup.sh
@@ -2145,14 +2145,14 @@ print_post_install() {
     echo -e "  ${YELLOW}View full keys with:${NC} cd ${INSTALL_DIR} && ./manage.sh keys"
     echo ""
 
-    if [[ "$SERVICES_STARTED" == "true" && -n "${RADARR_ADMIN_PASS:-}" ]]; then
+    if [[ "$SERVICES_STARTED" == "true" && ( -n "${RADARR_ADMIN_PASS:-}" || -n "${SONARR_ADMIN_PASS:-}" || -n "${PROWLARR_ADMIN_PASS:-}" ) ]]; then
         echo -e "${BOLD}━━━━ Auto-Generated Admin Credentials ━━━━━━━━━━━━━━━━━━━━━${NC}"
         echo ""
         echo -e "  ${YELLOW}Save these credentials — you will need them to log in.${NC}"
         echo ""
-        echo -e "  ${BOLD}Radarr${NC}    Username: ${RADARR_ADMIN_USER}  Password: ${RADARR_ADMIN_PASS}"
-        echo -e "  ${BOLD}Sonarr${NC}    Username: ${SONARR_ADMIN_USER}  Password: ${SONARR_ADMIN_PASS}"
-        echo -e "  ${BOLD}Prowlarr${NC}  Username: ${PROWLARR_ADMIN_USER}  Password: ${PROWLARR_ADMIN_PASS}"
+        echo -e "  ${BOLD}Radarr${NC}    Username: ${RADARR_ADMIN_USER:-<not set>}  Password: ${RADARR_ADMIN_PASS:-<not set>}"
+        echo -e "  ${BOLD}Sonarr${NC}    Username: ${SONARR_ADMIN_USER:-<not set>}  Password: ${SONARR_ADMIN_PASS:-<not set>}"
+        echo -e "  ${BOLD}Prowlarr${NC}  Username: ${PROWLARR_ADMIN_USER:-<not set>}  Password: ${PROWLARR_ADMIN_PASS:-<not set>}"
         echo ""
     fi
 

--- a/setup.sh
+++ b/setup.sh
@@ -1974,8 +1974,14 @@ configure_plex_libraries() {
 
     # Remove expired claim token from .env (token expires in 4 min and is single-use)
     if [[ -f "${ENV_FILE}" ]]; then
-        grep -v '^PLEX_CLAIM=' "${ENV_FILE}" > "${ENV_FILE}.tmp" && mv "${ENV_FILE}.tmp" "${ENV_FILE}" || true
-        log_info "  Plex claim token removed from .env (expired after first use)."
+        local env_tmp
+        env_tmp="$(mktemp "${ENV_FILE}.tmp.XXXXXX")"
+        if grep -v '^PLEX_CLAIM=' "${ENV_FILE}" > "${env_tmp}"; then
+            mv "${env_tmp}" "${ENV_FILE}"
+            log_info "  Plex claim token removed from .env (expired after first use)."
+        else
+            rm -f "${env_tmp}"
+        fi
     fi
 }
 
@@ -2077,20 +2083,25 @@ configure_arr_auth() {
         -H "X-Api-Key: ${api_key}" \
         "${url}/api/v3/config/host/${auth_id}" \
         -d "$updated_auth" -o /dev/null 2>/dev/null && {
-        log_info "  ${name} auth set to Forms (Enabled) with auto-generated credentials."
-        local env_key
-        case "$name" in
-            Radarr)   env_key="RADARR_ADMIN_USER" ;;
-            Sonarr)   env_key="SONARR_ADMIN_USER" ;;
-            Prowlarr) env_key="PROWLARR_ADMIN_USER" ;;
-
-        esac
+            log_info "  ${name} auth set to Forms (Enabled) with auto-generated credentials."
+            local env_key
+            case "$name" in
+                Radarr)   env_key="RADARR_ADMIN_USER" ;;
+                Sonarr)   env_key="SONARR_ADMIN_USER" ;;
+                Prowlarr) env_key="PROWLARR_ADMIN_USER" ;;
+                *)        { log_warn "  Unsupported service name: ${name}"; return 1; } ;;
+            esac
 
             # Remove old entries and append new ones
-            grep -v "^${env_key}_USER=\|^${env_key}_PASS=" "${ENV_FILE}" > "${ENV_FILE}.tmp" 2>/dev/null || true
-            echo "${env_key}_USER=\"${admin_user}\"" >> "${ENV_FILE}.tmp"
-            echo "${env_key}_PASS=\"${admin_pass}\"" >> "${ENV_FILE}.tmp"
-            mv "${ENV_FILE}.tmp" "${ENV_FILE}"
+            local env_tmp
+            env_tmp="$(mktemp "${ENV_FILE}.tmp.XXXXXX")"
+            if grep -v "^${env_key}_USER=\\|^${env_key}_PASS=" "${ENV_FILE}" > "${env_tmp}" 2>/dev/null; then
+                echo "${env_key}_USER=\"${admin_user}\"" >> "${env_tmp}"
+                echo "${env_key}_PASS=\"${admin_pass}\"" >> "${env_tmp}"
+                mv "${env_tmp}" "${ENV_FILE}"
+            else
+                rm -f "${env_tmp}"
+            fi
             chmod 600 "${ENV_FILE}"
         }
     } || log_warn "  Failed to configure ${name} auth."

--- a/tests/test_setup_functions.sh
+++ b/tests/test_setup_functions.sh
@@ -318,11 +318,19 @@ test_image_versions_not_latest() {
         echo -e "${CYAN}[SKIP]${NC} Cannot find docker-compose.yml to check image versions"
         return
     fi
-    if grep -qE 'image:.*:latest' "$compose_file" 2>/dev/null; then
-        fail "Found Docker images using :latest tag"
-    else
-        pass "No Docker images use :latest tag"
-    fi
+
+    local line
+    while IFS= read -r line; do
+        # Skip template variables like "${SERVICE_IMAGE:-...}"
+        if [[ "$line" == *"\${"* && "$line" == *":latest"* ]]; then
+            continue
+        fi
+        if [[ "$line" == *":latest"* ]]; then
+            fail "Found Docker image using :latest tag: $line"
+            return
+        fi
+    done < <(grep '^[[:space:]]*image:' "$compose_file" 2>/dev/null)
+    pass "No Docker images use :latest tag"
 }
 
 # ============================================================================

--- a/tests/test_setup_functions.sh
+++ b/tests/test_setup_functions.sh
@@ -334,19 +334,19 @@ test_image_versions_not_latest() {
 }
 
 # ============================================================================
-#  Function: docker-compose volume mounts (Decypharr read-only)
+#  Function: docker-compose volume mounts (Decypharr writable config)
 # ============================================================================
 
-test_decypharr_config_mount_readonly() {
+test_decypharr_config_mount_writable() {
     local compose_file="${SCRIPT_DIR}/../docker-compose.yml"
     if [[ ! -f "$compose_file" ]]; then
         echo -e "${CYAN}[SKIP]${NC} Cannot find docker-compose.yml to check Decypharr mount"
         return
     fi
-    if grep -q 'config.json:/app/config.json:ro' "$compose_file"; then
-        pass "Decypharr config.json is mounted as read-only file"
+    if grep -q '"${CONFIG_DIR}/decypharr:/app"' "$compose_file"; then
+        pass "Decypharr config directory is mounted writable"
     else
-        fail "Decypharr config should use file-level :ro mount"
+        fail "Decypharr config directory should be mounted writable at /app"
     fi
 }
 
@@ -401,7 +401,7 @@ test_hex_key_validation_with_letters
 echo ""
 echo "--- Docker compose template tests ---"
 test_image_versions_not_latest
-test_decypharr_config_mount_readonly
+test_decypharr_config_mount_writable
 
 echo ""
 echo "--- Feature detection tests ---"


### PR DESCRIPTION
This pull request introduces improvements to Docker image management and environment configuration, focusing on making image versions configurable and ensuring smoother upgrades. The main changes include parameterizing Docker image tags in `docker-compose.yml`, enhancing the setup script (`setup.sh`) to preserve and migrate existing image references, and improving robustness in environment file handling. Additionally, a test is updated to account for the new image variable pattern.

**Docker image management and configuration:**

* All major service images in `docker-compose.yml` (e.g., `decypharr`, `prowlarr`, `radarr`, `sonarr`, `byparr`, `seerr`, `plex`, `jellyfin`) are now parameterized using environment variables, defaulting to their respective `:latest` tags if not set. This allows users to override image versions via `.env` without editing the compose file directly. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L16-L40) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L53-R47) [[3]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L84-R78) [[4]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L111-R105) [[5]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L145-R139) [[6]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L178-R172) [[7]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L206-R200) [[8]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L240-R234)

* The setup script (`setup.sh`) is updated to:
  - Detect and preserve existing image variables from previous installations. [[1]](diffhunk://#diff-4209d788ad32c40cbda3c66b3de47eefb929308ca703bb77a6382625986add17R2405-R2412) [[2]](diffhunk://#diff-4209d788ad32c40cbda3c66b3de47eefb929308ca703bb77a6382625986add17R2449-R2479)
  - Migrate legacy hardcoded image tags to the new variable-based system, ensuring seamless upgrades.
  - Generate `.env` entries for all service images, using either existing, user-supplied, or default values. [[1]](diffhunk://#diff-4209d788ad32c40cbda3c66b3de47eefb929308ca703bb77a6382625986add17R886-R894) [[2]](diffhunk://#diff-4209d788ad32c40cbda3c66b3de47eefb929308ca703bb77a6382625986add17R934-R941)

**Robustness and maintainability improvements:**

* Temporary files in `setup.sh` are now handled more safely when updating the `.env` file, reducing the risk of file corruption. [[1]](diffhunk://#diff-4209d788ad32c40cbda3c66b3de47eefb929308ca703bb77a6382625986add17L1977-R2001) [[2]](diffhunk://#diff-4209d788ad32c40cbda3c66b3de47eefb929308ca703bb77a6382625986add17L2086-L2095)

* The dependency installation logic for Docker on Arch Linux is corrected to use the appropriate package names.

**Testing adjustments:**

* The test for image version pinning is updated to ignore parameterized `:latest` tags (i.e., those using variable substitution), only failing if a hardcoded `:latest` is found.

**Other compose adjustments:**

* Healthcheck conditions for Radarr and Sonarr are relaxed from `service_healthy` to `service_started` to accommodate the removal of Decypharr's healthcheck. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L129-R123) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L163-R157)
* Decypharr's port binding and volume mounts are updated for broader compatibility, and its healthcheck is removed.

These changes make the stack more flexible, easier to upgrade, and safer to maintain.

Was looping, causing system to be unresponsive, hence, the pr to fix it.