### PR TITLE
Fix Seerr docker image tag

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -175,7 +175,7 @@ services:
   # ── Seerr ───────────────────────────────────────────────────────
   # Media request & discovery frontend.
   seerr:
-    image: ghcr.io/seerr-team/seerr:2.4.1
+    image: ghcr.io/seerr-team/seerr:v3.2.0
     container_name: seerr
     user: "${PUID}:${PGID}"
     restart: unless-stopped


### PR DESCRIPTION
Fixes a bug where the stack failed to deploy due to an invalid image tag for Seerr by updating the tag to the latest stable release `v3.2.0`.

---
*PR created automatically by Jules for task [2237022820497484259](https://jules.google.com/task/2237022820497484259) started by @nordicnode*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/nordicnode/torbox-media-server/pull/14" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->