### PR TITLE
Fix byparr image tag to latest

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,7 +81,7 @@ services:
   # ── Byparr ────────────────────────────────────────────────────
   # Cloudflare bypass proxy (Byparr - drop-in FlareSolverr replacement).
   byparr:
-    image: ghcr.io/thephaseless/byparr:1.2.2
+    image: ghcr.io/thephaseless/byparr:latest
     container_name: byparr
     restart: unless-stopped
     networks:

--- a/tests/test_setup_functions.sh
+++ b/tests/test_setup_functions.sh
@@ -318,7 +318,7 @@ test_image_versions_not_latest() {
         echo -e "${CYAN}[SKIP]${NC} Cannot find docker-compose.yml to check image versions"
         return
     fi
-    if grep -qE 'image:.*:latest' "$compose_file" 2>/dev/null; then
+    if grep -v 'byparr' "$compose_file" | grep -qE 'image:.*:latest' 2>/dev/null; then
         fail "Found Docker images using :latest tag"
     else
         pass "No Docker images use :latest tag"


### PR DESCRIPTION
Update the byparr image tag from a non-existent version 1.2.2 to latest to fix pulling the image, as requested by the user.

- Updated `docker-compose.yml` image tag for `byparr` service to `latest`.
- Updated `tests/test_setup_functions.sh` to exempt `byparr` from the strict check for `:latest` tags in `docker-compose.yml`.

---
*PR created automatically by Jules for task [9096607078270384501](https://jules.google.com/task/9096607078270384501) started by @nordicnode*